### PR TITLE
Fix missing include for rpi4 / arm64

### DIFF
--- a/Nuitrack/include/nuitrack/types/NuitrackDevice.h
+++ b/Nuitrack/include/nuitrack/types/NuitrackDevice.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <vector>
+#include <cstring>
 
 #include "nuitrack/capi/NuitrackDevice_CAPI.h"
 #include "nuitrack/utils/ExceptionTranslator.h"


### PR DESCRIPTION
When compiling against the SDK on a raspberry pi 4, I get the following error. I do not get this error on windows. The fix appears to be to just add an '#include <cstring>' in NuitrackDevice.h.

```
error: failed to run custom build command for `nuitrack-rs v0.0.3`

Caused by:
  process didn't exit successfully: `/home/jgilby/mesa-kiosk/src-tauri/target/release/build/nuitrack-rs-dac02e391c0e2358/build-script-build` (exit status: 1)
  --- stdout
  cargo:warning=Desired Nuitrack SDK tag: v0.38
  cargo:warning=Attempting to resolve latest tag for prefix: v0.38 using pattern: refs/tags/v0.38*
  cargo:warning=Resolved tag for specifier 'v0.38' to: v0.38.4
  cargo:warning=Resolved Nuitrack SDK tag for operations: v0.38.4
  cargo:warning=Vendoring Nuitrack SDK tag v0.38.4 into "/home/jgilby/mesa-kiosk/src-tauri/target/release/build/nuitrack-rs-0360b33f3ce777c0/out/vendor/nuitrack-sdk"...
  cargo:warning=Cloning Nuitrack SDK repository https://github.com/3DiVi/nuitrack-sdk.git (tag v0.38.4) into "/home/jgilby/mesa-kiosk/src-tauri/target/release/build/nuitrack-rs-0360b33f3ce777c0/out/vendor/nuitrack-sdk" using git.
  cargo:warning=Nuitrack SDK successfully cloned and checked out at commit 2f56633.
  cargo:warning=Successfully cloned Nuitrack SDK tag v0.38.4.
  cargo:warning=Scanning for FFI headers in "/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge" to find modules...
  cargo:warning=Found FFI module: .h: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/core.h, .rs: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/core.rs, .cc: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/core.cc
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/core.h
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/core.rs
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/core.cc
  cargo:warning=Found FFI module: .h: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/device.h, .rs: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/device.rs, .cc: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/device.cc
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/device.h
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/device.rs
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/device.cc
  cargo:warning=Found FFI module: .h: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/modules/skeleton_tracker.h, .rs: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/modules/skeleton_tracker.rs, .cc: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/modules/skeleton_tracker.cc
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/modules/skeleton_tracker.h
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/modules/skeleton_tracker.rs
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/modules/skeleton_tracker.cc
  cargo:warning=Found FFI module: .h: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/modules/color_sensor.h, .rs: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/modules/color_sensor.rs, .cc: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/modules/color_sensor.cc
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/modules/color_sensor.h
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/modules/color_sensor.rs
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/modules/color_sensor.cc
  cargo:warning=Found FFI module: .h: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/modules/hand_tracker.h, .rs: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/modules/hand_tracker.rs, .cc: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/modules/hand_tracker.cc
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/modules/hand_tracker.h
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/modules/hand_tracker.rs
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/modules/hand_tracker.cc
  cargo:warning=Found FFI module: .h: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/types/hand.h, .rs: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/hand.rs, .cc: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/hand.cc
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/types/hand.h
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/hand.rs
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/hand.cc
  cargo:warning=Found FFI module: .h: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/types/skeleton_data.h, .rs: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/skeleton_data.rs, .cc: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/skeleton_data.cc
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/types/skeleton_data.h
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/skeleton_data.rs
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/skeleton_data.cc
  cargo:warning=Found FFI module: .h: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/types/skeleton.h, .rs: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/skeleton.rs, .cc: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/skeleton.cc
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/types/skeleton.h
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/skeleton.rs
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/skeleton.cc
  cargo:warning=Found FFI module: .h: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/types/hand_data.h, .rs: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/hand_data.rs, .cc: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/hand_data.cc
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/types/hand_data.h
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/hand_data.rs
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/hand_data.cc
  cargo:warning=Found FFI module: .h: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/types/output_mode.h, .rs: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/output_mode.rs, .cc: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/output_mode.cc
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/types/output_mode.h
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/output_mode.rs
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/output_mode.cc
  cargo:warning=Found FFI module: .h: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/types/rgb_frame.h, .rs: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/rgb_frame.rs, .cc: /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/rgb_frame.cc
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/types/rgb_frame.h
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/rgb_frame.rs
  cargo:rerun-if-changed=/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/src/nuitrack_bridge/types/rgb_frame.cc
  cargo:warning=Relative RS bridge files for cxx_build: ["src/nuitrack_bridge/core.rs", "src/nuitrack_bridge/device.rs", "src/nuitrack_bridge/modules/skeleton_tracker.rs", "src/nuitrack_bridge/modules/color_sensor.rs", "src/nuitrack_bridge/modules/hand_tracker.rs", "src/nuitrack_bridge/types/hand.rs", "src/nuitrack_bridge/types/skeleton_data.rs", "src/nuitrack_bridge/types/skeleton.rs", "src/nuitrack_bridge/types/hand_data.rs", "src/nuitrack_bridge/types/output_mode.rs", "src/nuitrack_bridge/types/rgb_frame.rs"]
  cargo:warning=Relative CC impl files for cxx_build: ["src/nuitrack_bridge/core.cc", "src/nuitrack_bridge/device.cc", "src/nuitrack_bridge/modules/skeleton_tracker.cc", "src/nuitrack_bridge/modules/color_sensor.cc", "src/nuitrack_bridge/modules/hand_tracker.cc", "src/nuitrack_bridge/types/hand.cc", "src/nuitrack_bridge/types/skeleton_data.cc", "src/nuitrack_bridge/types/skeleton.cc", "src/nuitrack_bridge/types/hand_data.cc", "src/nuitrack_bridge/types/output_mode.cc", "src/nuitrack_bridge/types/rgb_frame.cc"]
  cargo:CXXBRIDGE_PREFIX=nuitrack-rs
  cargo:CXXBRIDGE_LINKS=nuitrack
  cargo:CXXBRIDGE_DIR0=/home/jgilby/mesa-kiosk/src-tauri/target/release/build/nuitrack-rs-0360b33f3ce777c0/out/cxxbridge/include
  cargo:CXXBRIDGE_DIR1=/home/jgilby/mesa-kiosk/src-tauri/target/release/build/nuitrack-rs-0360b33f3ce777c0/out/cxxbridge/crate
  OUT_DIR = Some(/home/jgilby/mesa-kiosk/src-tauri/target/release/build/nuitrack-rs-0360b33f3ce777c0/out)
  OPT_LEVEL = Some(3)
  TARGET = Some(aarch64-unknown-linux-gnu)
  HOST = Some(aarch64-unknown-linux-gnu)
  cargo:rerun-if-env-changed=CXX_aarch64-unknown-linux-gnu
  CXX_aarch64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=CXX_aarch64_unknown_linux_gnu
  CXX_aarch64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_CXX
  HOST_CXX = None
  cargo:rerun-if-env-changed=CXX
  CXX = None
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  RUSTC_WRAPPER = None
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some(false)
  CARGO_CFG_TARGET_FEATURE = Some(neon)
  cargo:rerun-if-env-changed=CXXFLAGS
  CXXFLAGS = None
  cargo:rerun-if-env-changed=HOST_CXXFLAGS
  HOST_CXXFLAGS = None
  cargo:rerun-if-env-changed=CXXFLAGS_aarch64_unknown_linux_gnu
  CXXFLAGS_aarch64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=CXXFLAGS_aarch64-unknown-linux-gnu
  CXXFLAGS_aarch64-unknown-linux-gnu = None
  CARGO_ENCODED_RUSTFLAGS = Some()
  OUT_DIR = Some(/home/jgilby/mesa-kiosk/src-tauri/target/release/build/nuitrack-rs-0360b33f3ce777c0/out)
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  TARGET = Some(aarch64-unknown-linux-gnu)
  CARGO_CFG_TARGET_FEATURE = Some(neon)
  HOST = Some(aarch64-unknown-linux-gnu)
  cargo:rerun-if-env-changed=CXXFLAGS
  CXXFLAGS = None
  cargo:rerun-if-env-changed=HOST_CXXFLAGS
  HOST_CXXFLAGS = None
  cargo:rerun-if-env-changed=CXXFLAGS_aarch64_unknown_linux_gnu
  CXXFLAGS_aarch64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=CXXFLAGS_aarch64-unknown-linux-gnu
  CXXFLAGS_aarch64-unknown-linux-gnu = None
  cargo:warning=In file included from /home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include/nuitrack_bridge/device.h:5,
  cargo:warning=                 from /home/jgilby/mesa-kiosk/src-tauri/target/release/build/nuitrack-rs-0360b33f3ce777c0/out/cxxbridge/sources/nuitrack-rs/src/nuitrack_bridge/device.rs.cc:1:
  cargo:warning=/home/jgilby/mesa-kiosk/src-tauri/target/release/build/nuitrack-rs-0360b33f3ce777c0/out/vendor/nuitrack-sdk/Nuitrack/include/nuitrack/types/NuitrackDevice.h: In member function 'std::string tdv::nuitrack::device::NuitrackDevice::getInfo(tdv::nuitrack::device::DeviceInfoType)':
  cargo:warning=/home/jgilby/mesa-kiosk/src-tauri/target/release/build/nuitrack-rs-0360b33f3ce777c0/out/vendor/nuitrack-sdk/Nuitrack/include/nuitrack/types/NuitrackDevice.h:40:31: error: 'strlen' was not declared in this scope
  cargo:warning=   40 |                 result.resize(strlen(result.c_str()));
  cargo:warning=      |                               ^~~~~~
  cargo:warning=/home/jgilby/mesa-kiosk/src-tauri/target/release/build/nuitrack-rs-0360b33f3ce777c0/out/vendor/nuitrack-sdk/Nuitrack/include/nuitrack/types/NuitrackDevice.h:6:1: note: 'strlen' is defined in header '<cstring>'; did you forget to '#include <cstring>'?
  cargo:warning=    5 | #include "nuitrack/utils/ExceptionTranslator.h"
  cargo:warning=  +++ |+#include <cstring>
  cargo:warning=    6 | 

  --- stderr
  Cloning into '/home/jgilby/mesa-kiosk/src-tauri/target/release/build/nuitrack-rs-0360b33f3ce777c0/out/vendor/nuitrack-sdk'...
  Note: switching to '2f5663373a8681364eabd1c213f6cb2a470d3224'.

  You are in 'detached HEAD' state. You can look around, make experimental
  changes and commit them, and you can discard any commits you make in this
  state without impacting any branches by switching back to a branch.

  If you want to create a new branch to retain commits you create, you may
  do so (now or later) by using -c with the switch command. Example:

    git switch -c <new-branch-name>

  Or undo this operation with:

    git switch -

  Turn off this advice by setting config variable advice.detachedHead to false

Updating files: 100% (819/819), done.
  HEAD is now at 2f56633 Nuitrack v0.38.4

  CXX include path:
    /home/jgilby/mesa-kiosk/src-tauri/target/release/build/nuitrack-rs-0360b33f3ce777c0/out/cxxbridge/include
    /home/jgilby/mesa-kiosk/src-tauri/target/release/build/nuitrack-rs-0360b33f3ce777c0/out/cxxbridge/crate


  error occurred in cc-rs: command did not execute successfully (status code exit status: 1): LC_ALL="C" "c++" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-std=c++17" "-I" "/home/jgilby/mesa-kiosk/src-tauri/target/release/build/nuitrack-rs-0360b33f3ce777c0/out/cxxbridge/include" "-I" "/home/jgilby/mesa-kiosk/src-tauri/target/release/build/nuitrack-rs-0360b33f3ce777c0/out/cxxbridge/crate" "-I" "/home/jgilby/mesa-kiosk/src-tauri/target/release/build/nuitrack-rs-0360b33f3ce777c0/out/vendor/nuitrack-sdk/Nuitrack/include" "-I" "/home/jgilby/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nuitrack-rs-0.0.3/include" "-Wall" "-Wextra" "-DNDEBUG" "-o" "/home/jgilby/mesa-kiosk/src-tauri/target/release/build/nuitrack-rs-0360b33f3ce777c0/out/f33aa09a2bd4dd02-device.rs.o" "-c" "/home/jgilby/mesa-kiosk/src-tauri/target/release/build/nuitrack-rs-0360b33f3ce777c0/out/cxxbridge/sources/nuitrack-rs/src/nuitrack_bridge/device.rs.cc"


warning: build failed, waiting for other jobs to finish...
failed to build app: failed to build app
       Error failed to build app: failed to build app
â€ELIFECYCLEâ€ Command failed with exit code 1.
```